### PR TITLE
Fixing length of reference to 50

### DIFF
--- a/src/Api/Options/RequestResolver.php
+++ b/src/Api/Options/RequestResolver.php
@@ -53,7 +53,7 @@ class RequestResolver extends OptionsResolver
             ->setAllowedValues('currency', Assert::currency())
             ->setAllowedTypes('reference', 'string')
             ->setAllowedValues('reference', function ($value) {
-                return preg_match('~^[0-9A-Za-z]{1,12}$~', $value);
+                return preg_match('~^[0-9A-Za-z]{1,50}$~', $value);
             });
 
         $this


### PR DESCRIPTION
Fixing length to 50 as described in https://github.com/ekyna/PayumMoneticoBundle/issues/3