### PR TITLE
Add psr/log v2 requirements

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     "require": {
         "ext-json": "*",
         "payum/core": "^1.5",
-        "psr/log": "^1.0|^3.0",
+        "psr/log": "^1.0|^2.0|^3.0",
         "symfony/options-resolver": "^5.4|^6.0",
         "sokil/php-isocodes": "^2.0|^3.0"
     },


### PR DESCRIPTION
https://packagist.org/packages/psr/log#2.0.0
https://packagist.org/packages/psr/log#3.0.0

Are almost the same version but some packages like Sylius can use `psr/log:^2.0` making this package not installable.